### PR TITLE
Fixed (based)pyright crash

### DIFF
--- a/lua/devcontainers/cli.lua
+++ b/lua/devcontainers/cli.lua
@@ -211,7 +211,7 @@ end
 ---@param workspace_dir string
 ---@return boolean
 function M.container_is_running(workspace_dir)
-    local ok = pcall(M.exec, workspace_dir, 'echo')
+    local ok = pcall(M.exec, workspace_dir, {'echo'})
     return ok
 end
 

--- a/lua/devcontainers/lsp/rpc.lua
+++ b/lua/devcontainers/lsp/rpc.lua
@@ -195,6 +195,13 @@ function M.wrap_client_to_server(rpc, mappings, fn)
             -- if it ever becomes bottleneck we may try to limit it to only the `params` that we modify.
             -- `noref=true` seems to be more performant for LSP from my benchmarks.
             params = vim.deepcopy(params, true)
+			
+			-- (Based)pyright checks whether LSP is running via kill(PID, 0), fails because container doesn't have host PID or smth. See: https://github.com/microsoft/pyright/discussions/5917
+			if method == "initialize" and params and params.processId then
+				log.trace("Nullifying processId in initialize request to prevent container PID namespace issues")
+				params.processId = vim.NIL
+			end
+
             log.debug('client2server:request:%s', method)
             log.trace('params=%s', utils.lazy_inspect_oneline(params))
             params = apply(params, fn, {


### PR DESCRIPTION
Found the reason why pyright was crashing after a couple sec: https://github.com/microsoft/pyright/discussions/5917

Not sure about the exacts, but it has to do with pyright checking live status via kill(PID, 0) and the PID not being present in the devcontainer, making it quit itself. Simply setting PID to nil avoids this check (and doesn't seem to interfere with LSPs as far as I could see).